### PR TITLE
Use correct package for g++ with RHEL and CentOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ Make sure you have installed the equivalent for each of these packages for your 
 Shortcut commands for installing pre-requisites:
 ```
 # RHEL / CentOS Based:
-yum install automake bzip2 cmake make g++ gcc git openssl openssl-devel patch
+yum install automake bzip2 cmake make gcc-c++ gcc git openssl openssl-devel patch
 
 # Debian / Ubuntu Based:
 apt-get install automake bzip2 cmake make g++ gcc git openssl libssl-dev patch


### PR DESCRIPTION
As of CentOS 7.4 and Fedora 28, the correct package name to install `g++` is `gcc-c++`.